### PR TITLE
Add example alerts to kube-prometheus example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ The kustomization config does the following:
 - patches the `kube-state-metrics` ClusterRole with permissions for `customresourcedefinitions`
 and the various Gateway API resources in the `gateway.networking.k8s.io` apiGroup
 - changes the kube-state-metrics image to a version that supports CustomResourceState and has various issues fixed.
+- includes example Grafana dashboards
+- includes example Prometheus Alert rules
 
 ## Dashboards
 
-An set of Grafana dashboards are available in [./examples/dashboards](./examples/dashboards).
+A set of Grafana dashboards are available in [./examples/dashboards](./examples/dashboards).
 You can import them directly into Grafana and modify as needed.
 The dashboards are divided by resources (GatewayClasses, Gateways and HTTPRoutes),
 with variables for filtering, and links to drill down from a GatewayClass to a
@@ -38,6 +40,10 @@ Gateway to a HTTPRoute.
 
 <img src="httproutes.png" alt="httproutes" width="800"/>
 
+## Alerts
+
+A set of example Alerts are available in [./examples/rules](./examples/rules).
+You can create the PrometheusRule resource directly or modify it as needed.
 
 ## Metrics
 

--- a/examples/kube-prometheus/README.md
+++ b/examples/kube-prometheus/README.md
@@ -20,8 +20,18 @@ kustomize build . | docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinit
 To access the dashboards in Grafana, use the port-forward command:
 
 ```bash
+kubectl wait --timeout=5m -n monitoring deployment/grafana --for=condition=Available
 kubectl -n monitoring port-forward service/grafana 3000:3000 &
 ```
 
 Then navigate to http://localhost:3000
-The Gateway API State dashboards will be available in the 'General' folder.
+The Gateway API State dashboards will be available in the 'Default' folder.
+
+To access the prometheus UI, use this port-forward command:
+
+```bash
+kubectl -n monitoring port-forward service/prometheus-k8s 9090:9090 &
+```
+
+Then navigate to http://localhost:9090
+You should see some example Gateway API alerts in the 'Alerts' tab.

--- a/examples/kube-prometheus/kustomization.yaml
+++ b/examples/kube-prometheus/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - github.com/prometheus-operator/kube-prometheus?ref=release-0.11
   - github.com/david-martin/gateway-api-state-metrics?ref=main
   - ../dashboards
+  - ../rules
 
 patchesJson6902:
   - target:

--- a/examples/rules/alert-rules.yaml
+++ b/examples/rules/alert-rules.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: gateway-api-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: gateway-api.rules
+    rules:
+    - alert: UnhealthyGateway
+      annotations:
+        description: Gateway {{ $labels.namespace }}/{{$labels.name}} has an unhealthy status
+        summary: Either the Accepted or Programmed status is not True
+      expr: |
+        (gatewayapi_gateway_status{type="Accepted"} == 0) or (gatewayapi_gateway_status{type="Programmed"} == 0)
+      for: 10m
+      labels:
+        severity: critical
+    - alert: InsecureHTTPListener
+      annotations:
+        description: Gateway {{ $labels.namespace }}/{{$labels.name}} has an insecure listener {{$labels.protocol}}/{{$labels.port}}
+        summary: Listeners must use HTTPS
+      expr: |
+        gatewayapi_gateway_listener_info{protocol="HTTP"}
+      for: 10m
+      labels:
+        severity: critical

--- a/examples/rules/kustomization.yaml
+++ b/examples/rules/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - alert-rules.yaml


### PR DESCRIPTION
Closes #6 

Adds 2 rules:

- UnhealthyGateway, based on gateway status
- InsecureHTTPListener, based on the listener protocol