### PR TITLE
Move kuadrant resources to separate kustomization file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Download Kustomize
       run: |
         curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
@@ -56,3 +56,20 @@ jobs:
             echo "::error:: Bundles comparison failed. Please run 'make generate-bundles' and check in changes."
             exit 1
           fi
+
+  check-kuadrant-custom-resource-state:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Execute generation script
+      run: ./hack/gen_kuadrant_custom_resource_state.sh
+
+    - name: Check for changes in generated file
+      run: |
+        if ! git diff --exit-code ./config/kuadrant/custom-resource-state.yaml; then
+          echo "The generated file ./config/kuadrant/custom-resource-state.yaml has changes."
+          echo "Please run './hack/gen_kuadrant_custom_resource_state.sh' locally and check in the changes."
+          exit 1
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/*
 
 log/
 /vendor/
+.vscode/

--- a/config/examples/kube-prometheus/bundle.yaml
+++ b/config/examples/kube-prometheus/bundle.yaml
@@ -1700,6 +1700,45 @@ data:
                 labelsFromPath:
                   type: ["type"]
                 valueFrom: ["status"]
+        - groupVersionKind:
+            group: kuadrant.io
+            kind: "DNSRecord"
+            version: "v1alpha1"
+          metricNamePrefix: kuadrant_dnsrecord
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+            rootDomain:
+            - spec
+            - rootHost
+          metrics:
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "status_root_domain_owners"
+            help: "root domain owners (the ids of controllers managing this root domain)"
+            each:
+              type: Info
+              info:
+                path: [status, domainOwners]
+                labelsFromPath:
+                  owner: []
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
 kind: ConfigMap
 metadata:
   name: custom-resource-state

--- a/config/examples/kube-prometheus/bundle.yaml
+++ b/config/examples/kube-prometheus/bundle.yaml
@@ -982,281 +982,724 @@ metadata:
 ---
 apiVersion: v1
 data:
-  custom-resource-state.yaml: "kind: CustomResourceStateMetrics\nspec:\n  resources:\n
-    \   - groupVersionKind:\n        group: gateway.networking.k8s.io\n        kind:
-    \"Gateway\"\n        version: \"v1beta1\"\n      metricNamePrefix: gatewayapi_gateway\n
-    \     labelsFromPath:\n        name:\n        - metadata\n        - name\n        namespace:\n
-    \       - metadata\n        - namespace\n      metrics:\n      - name: \"info\"\n
-    \       help: \"Gateway information\"\n        each:\n          type: Info\n          info:\n
-    \           labelsFromPath:\n              gatewayclass_name: [spec, gatewayClassName]\n
-    \     - name: \"labels\"\n        help: \"Kubernetes labels converted to Prometheus
-    labels.\"\n        each:\n          type: Info\n          info:\n            path:
-    [metadata]\n            labelsFromPath:\n              \"*\": [labels]\n      -
-    name: \"created\"\n        help: \"created timestamp\"\n        each:\n          type:
-    Gauge\n          gauge:\n            path: [metadata, creationTimestamp]\n      -
-    name: \"deleted\"\n        help: \"deletion timestamp\"\n        each:\n          type:
-    Gauge\n          gauge:\n            path: [metadata, deletionTimestamp]\n      -
-    name: \"listener_info\"\n        help: \"Gateway listener information\"\n        each:\n
-    \         type: Info\n          info:\n            path: [spec, listeners]\n            labelsFromPath:\n
-    \             listener_name: [\"name\"]\n              port: [\"port\"]\n              protocol:
-    [\"protocol\"]\n              hostname: [\"hostname\"]\n              tls_mode:
-    [\"tls\",\"mode\"]\n              allowed_routes_namespaces_from: [\"allowedRoutes\",
-    \"namespaces\", \"from\"]\n      - name: \"status\"\n        help: \"status condition\"\n
-    \       each:\n          type: Gauge\n          gauge:\n            path: [status,
-    conditions]\n            labelsFromPath:\n              type: [\"type\"]\n            valueFrom:
-    [\"status\"]\n      - name: \"status_listener_attached_routes\"\n        help:
-    \"Number of attached routes for a listener\"\n        each:\n          type: Gauge\n
-    \         gauge:\n            path: [status, listeners]\n            labelsFromPath:\n
-    \             listener_name: [\"name\"]\n            valueFrom: [\"attachedRoutes\"]\n
-    \     - name: \"status_address_info\"\n        help: \"Gateway address types and
-    values\"\n        each:\n          type: Info\n          info:\n            path:
-    [status, addresses]\n            labelsFromPath:\n              type: [\"type\"]\n
-    \             value: [\"value\"]\n    - groupVersionKind:\n        group: gateway.networking.k8s.io\n
-    \       kind: \"GatewayClass\"\n        version: \"v1beta1\"\n      metricNamePrefix:
-    gatewayapi_gatewayclass\n      labelsFromPath:\n        name:\n        - metadata\n
-    \       - name\n      metrics:\n      - name: \"info\"\n        help: \"GatewayClass
-    information\"\n        each:\n          type: Info\n          info:\n            labelsFromPath:\n
-    \             controller_name: [spec, controllerName]\n      - name: \"labels\"\n
-    \       help: \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n
-    \         type: Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"status\"\n        help: \"status
-    condition\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [status, conditions]\n            labelsFromPath:\n              type: [\"type\"]\n
-    \           valueFrom: [\"status\"]\n      - name: \"status_supported_features\"\n
-    \       help: \"List of supported features for the GatewayClass\"\n        each:\n
-    \         type: Info\n          info:\n            path: [status, supportedFeatures]\n
-    \           labelsFromPath:\n              features: []\n    - groupVersionKind:\n
-    \       group: gateway.networking.k8s.io\n        kind: \"HTTPRoute\"\n        version:
-    \"v1beta1\"\n      metricNamePrefix: gatewayapi_httproute\n      labelsFromPath:\n
-    \       name:\n        - metadata\n        - name\n        namespace:\n        -
-    metadata\n        - namespace\n      metrics:\n      - name: \"labels\"\n        help:
-    \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n          type:
-    Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"hostname_info\"\n        help:
-    \"Hostname information\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, hostnames]\n            labelsFromPath:\n              hostname:
-    []\n      - name: \"parent_info\"\n        help: \"Parent references that the
-    httproute wants to be attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, parentRefs]\n            labelsFromPath:\n              parent_group:
-    [\"group\"]\n              parent_kind: [\"kind\"]\n              parent_name:
-    [\"name\"]\n              parent_namespace: [\"namespace\"]\n              parent_section_name:
-    [\"sectionName\"]\n              parent_port: [\"port\"]\n      - name: \"status_parent_info\"\n
-    \       help: \"Parent references that the httproute is attached to\"\n        each:\n
-    \         type: Info\n          info:\n            path: [status, parents]\n            labelsFromPath:\n
-    \             controller_name: [\"controllerName\"]\n              parent_group:
-    [\"parentRef\", \"group\"]\n              parent_kind: [\"parentRef\", \"kind\"]\n
-    \             parent_name: [\"parentRef\", \"name\"]\n              parent_namespace:
-    [\"parentRef\", \"namespace\"]\n              parent_section_name: [\"parentRef\",
-    \"sectionName\"]\n              parent_port: [\"parentRef\", \"port\"]\n    -
-    groupVersionKind:\n        group: gateway.networking.k8s.io\n        kind: \"GRPCRoute\"\n
-    \       version: \"v1alpha2\"\n      metricNamePrefix: gatewayapi_grpcroute\n
-    \     labelsFromPath:\n        name:\n        - metadata\n        - name\n        namespace:\n
-    \       - metadata\n        - namespace\n      metrics:\n      - name: \"labels\"\n
-    \       help: \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n
-    \         type: Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"hostname_info\"\n        help:
-    \"Hostname information\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, hostnames]\n            labelsFromPath:\n              hostname:
-    []\n      - name: \"parent_info\"\n        help: \"Parent references that the
-    grpcroute wants to be attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, parentRefs]\n            labelsFromPath:\n              parent_group:
-    [\"group\"]\n              parent_kind: [\"kind\"]\n              parent_name:
-    [\"name\"]\n              parent_namespace: [\"namespace\"]\n              parent_section_name:
-    [\"sectionName\"]\n              parent_port: [\"port\"]\n      - name: \"status_parent_info\"\n
-    \       help: \"Parent references that the grpcroute is attached to\"\n        each:\n
-    \         type: Info\n          info:\n            path: [status, parents]\n            labelsFromPath:\n
-    \             controller_name: [\"controllerName\"]\n              parent_group:
-    [\"parentRef\", \"group\"]\n              parent_kind: [\"parentRef\", \"kind\"]\n
-    \             parent_name: [\"parentRef\", \"name\"]\n              parent_namespace:
-    [\"parentRef\", \"namespace\"]\n              parent_section_name: [\"parentRef\",
-    \"sectionName\"]\n              parent_port: [\"parentRef\", \"port\"]\n    -
-    groupVersionKind:\n        group: gateway.networking.k8s.io\n        kind: \"TCPRoute\"\n
-    \       version: \"v1alpha2\"\n      metricNamePrefix: gatewayapi_tcproute\n      labelsFromPath:\n
-    \       name:\n        - metadata\n        - name\n        namespace:\n        -
-    metadata\n        - namespace\n      metrics:\n      - name: \"labels\"\n        help:
-    \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n          type:
-    Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"parent_info\"\n        help: \"Parent
-    references that the tcproute wants to be attached to\"\n        each:\n          type:
-    Info\n          info:\n            path: [spec, parentRefs]\n            labelsFromPath:\n
-    \             parent_group: [\"group\"]\n              parent_kind: [\"kind\"]\n
-    \             parent_name: [\"name\"]\n              parent_namespace: [\"namespace\"]\n
-    \             parent_section_name: [\"sectionName\"]\n              parent_port:
-    [\"port\"]\n      - name: \"status_parent_info\"\n        help: \"Parent references
-    that the tcproute is attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [status, parents]\n            labelsFromPath:\n              controller_name:
-    [\"controllerName\"]\n              parent_group: [\"parentRef\", \"group\"]\n
-    \             parent_kind: [\"parentRef\", \"kind\"]\n              parent_name:
-    [\"parentRef\", \"name\"]\n              parent_namespace: [\"parentRef\", \"namespace\"]\n
-    \             parent_section_name: [\"parentRef\", \"sectionName\"]\n              parent_port:
-    [\"parentRef\", \"port\"]\n    - groupVersionKind:\n        group: gateway.networking.k8s.io\n
-    \       kind: \"TLSRoute\"\n        version: \"v1alpha2\"\n      metricNamePrefix:
-    gatewayapi_tlsroute\n      labelsFromPath:\n        name:\n        - metadata\n
-    \       - name\n        namespace:\n        - metadata\n        - namespace\n
-    \     metrics:\n      - name: \"labels\"\n        help: \"Kubernetes labels converted
-    to Prometheus labels.\"\n        each:\n          type: Info\n          info:\n
-    \           path: [metadata]\n            labelsFromPath:\n              \"*\":
-    [labels]\n      - name: \"created\"\n        help: \"created timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, creationTimestamp]\n
-    \     - name: \"deleted\"\n        help: \"deletion timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, deletionTimestamp]\n
-    \     - name: \"hostname_info\"\n        help: \"Hostname information\"\n        each:\n
-    \         type: Info\n          info:\n            path: [spec, hostnames]\n            labelsFromPath:\n
-    \             hostname: []\n      - name: \"parent_info\"\n        help: \"Parent
-    references that the tlsroute wants to be attached to\"\n        each:\n          type:
-    Info\n          info:\n            path: [spec, parentRefs]\n            labelsFromPath:\n
-    \             parent_group: [\"group\"]\n              parent_kind: [\"kind\"]\n
-    \             parent_name: [\"name\"]\n              parent_namespace: [\"namespace\"]\n
-    \             parent_section_name: [\"sectionName\"]\n              parent_port:
-    [\"port\"]\n      - name: \"status_parent_info\"\n        help: \"Parent references
-    that the tlsroute is attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [status, parents]\n            labelsFromPath:\n              controller_name:
-    [\"controllerName\"]\n              parent_group: [\"parentRef\", \"group\"]\n
-    \             parent_kind: [\"parentRef\", \"kind\"]\n              parent_name:
-    [\"parentRef\", \"name\"]\n              parent_namespace: [\"parentRef\", \"namespace\"]\n
-    \             parent_section_name: [\"parentRef\", \"sectionName\"]\n              parent_port:
-    [\"parentRef\", \"port\"]\n    - groupVersionKind:\n        group: gateway.networking.k8s.io\n
-    \       kind: \"UDPRoute\"\n        version: \"v1alpha2\"\n      metricNamePrefix:
-    gatewayapi_udproute\n      labelsFromPath:\n        name:\n        - metadata\n
-    \       - name\n        namespace:\n        - metadata\n        - namespace\n
-    \     metrics:\n      - name: \"labels\"\n        help: \"Kubernetes labels converted
-    to Prometheus labels.\"\n        each:\n          type: Info\n          info:\n
-    \           path: [metadata]\n            labelsFromPath:\n              \"*\":
-    [labels]\n      - name: \"created\"\n        help: \"created timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, creationTimestamp]\n
-    \     - name: \"deleted\"\n        help: \"deletion timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, deletionTimestamp]\n
-    \     - name: \"parent_info\"\n        help: \"Parent references that the udproute
-    wants to be attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, parentRefs]\n            labelsFromPath:\n              parent_group:
-    [\"group\"]\n              parent_kind: [\"kind\"]\n              parent_name:
-    [\"name\"]\n              parent_namespace: [\"namespace\"]\n              parent_section_name:
-    [\"sectionName\"]\n              parent_port: [\"port\"]\n      - name: \"status_parent_info\"\n
-    \       help: \"Parent references that the udproute is attached to\"\n        each:\n
-    \         type: Info\n          info:\n            path: [status, parents]\n            labelsFromPath:\n
-    \             controller_name: [\"controllerName\"]\n              parent_group:
-    [\"parentRef\", \"group\"]\n              parent_kind: [\"parentRef\", \"kind\"]\n
-    \             parent_name: [\"parentRef\", \"name\"]\n              parent_namespace:
-    [\"parentRef\", \"namespace\"]\n              parent_section_name: [\"parentRef\",
-    \"sectionName\"]\n              parent_port: [\"parentRef\", \"port\"]\n    -
-    groupVersionKind:\n        group: kuadrant.io\n        kind: \"TLSPolicy\"\n        version:
-    \"v1alpha1\"\n      metricNamePrefix: gatewayapi_tlspolicy\n      labelsFromPath:\n
-    \       name:\n        - metadata\n        - name\n        namespace:\n        -
-    metadata\n        - namespace\n      metrics:\n      - name: \"labels\"\n        help:
-    \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n          type:
-    Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"target_info\"\n        help: \"Target
-    references that the tlspolicy wants to be attached to\"\n        each:\n          type:
-    Info\n          info:\n            path: [spec, targetRef]\n            labelsFromPath:\n
-    \             target_group: [\"group\"]\n              target_kind: [\"kind\"]\n
-    \             target_name: [\"name\"]\n              target_namespace: [\"namespace\"]\n
-    \     - name: \"status\"\n        help: \"status condition\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [status, conditions]\n
-    \           labelsFromPath:\n              type: [\"type\"]\n            valueFrom:
-    [\"status\"]\n    - groupVersionKind:\n        group: kuadrant.io\n        kind:
-    \"DNSRecord\"\n        version: \"v1alpha1\"\n      metricNamePrefix: kuadrant_dnsrecord
-    \           \n      labelsFromPath:\n        name:\n        - metadata\n        -
-    name\n        namespace:\n        - metadata\n        - namespace \n        rootDomain:\n
-    \       - spec\n        - rootHost     \n      metrics:\n      - name: \"created\"\n
-    \       help: \"created timestamp\"\n        each:\n          type: Gauge\n          gauge:\n
-    \           path: [metadata, creationTimestamp]      \n      - name: \"status_root_domain_owners\"\n
-    \       help: \"root domain owners (the ids of controllers managing this root
-    domain)\"\n        each:\n          type: Info\n          info:\n            path:
-    [status, domainOwners]\n            labelsFromPath:\n              owner: []\n
-    \     - name: \"status\"\n        help: \"status condition\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [status, conditions]\n
-    \           labelsFromPath:\n              type: [\"type\"]\n            valueFrom:
-    [\"status\"]              \n    - groupVersionKind:\n        group: kuadrant.io\n
-    \       kind: \"DNSPolicy\"\n        version: \"v1alpha1\"\n      metricNamePrefix:
-    gatewayapi_dnspolicy\n      labelsFromPath:\n        name:\n        - metadata\n
-    \       - name\n        namespace:\n        - metadata\n        - namespace\n
-    \     metrics:\n      - name: \"labels\"\n        help: \"Kubernetes labels converted
-    to Prometheus labels.\"\n        each:\n          type: Info\n          info:\n
-    \           path: [metadata]\n            labelsFromPath:\n              \"*\":
-    [labels]\n      - name: \"created\"\n        help: \"created timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, creationTimestamp]\n
-    \     - name: \"deleted\"\n        help: \"deletion timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, deletionTimestamp]\n
-    \     - name: \"target_info\"\n        help: \"Target references that the dnspolicy
-    wants to be attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, targetRef]\n            labelsFromPath:\n              target_group:
-    [\"group\"]\n              target_kind: [\"kind\"]\n              target_name:
-    [\"name\"]\n              target_namespace: [\"namespace\"]\n      - name: \"status\"\n
-    \       help: \"status condition\"\n        each:\n          type: Gauge\n          gauge:\n
-    \           path: [status, conditions]\n            labelsFromPath:\n              type:
-    [\"type\"]\n            valueFrom: [\"status\"]\n    - groupVersionKind:\n        group:
-    kuadrant.io\n        kind: \"RateLimitPolicy\"\n        version: \"v1beta2\"\n
-    \     metricNamePrefix: gatewayapi_ratelimitpolicy\n      labelsFromPath:\n        name:\n
-    \       - metadata\n        - name\n        namespace:\n        - metadata\n        -
-    namespace\n      metrics:\n      - name: \"labels\"\n        help: \"Kubernetes
-    labels converted to Prometheus labels.\"\n        each:\n          type: Info\n
-    \         info:\n            path: [metadata]\n            labelsFromPath:\n              \"*\":
-    [labels]\n      - name: \"created\"\n        help: \"created timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, creationTimestamp]\n
-    \     - name: \"deleted\"\n        help: \"deletion timestamp\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [metadata, deletionTimestamp]\n
-    \     - name: \"target_info\"\n        help: \"Target references that the tlspolicy
-    wants to be attached to\"\n        each:\n          type: Info\n          info:\n
-    \           path: [spec, targetRef]\n            labelsFromPath:\n              target_group:
-    [\"group\"]\n              target_kind: [\"kind\"]\n              target_name:
-    [\"name\"]\n              target_namespace: [\"namespace\"]\n      - name: \"status\"\n
-    \       help: \"status condition\"\n        each:\n          type: Gauge\n          gauge:\n
-    \           path: [status, conditions]\n            labelsFromPath:\n              type:
-    [\"type\"]\n            valueFrom: [\"status\"]\n    - groupVersionKind:\n        group:
-    gateway.networking.k8s.io\n        kind: \"BackendTLSPolicy\"\n        version:
-    \"v1alpha2\"\n      metricNamePrefix: gatewayapi_backendtlspolicy\n      labelsFromPath:\n
-    \       name:\n        - metadata\n        - name\n        namespace:\n        -
-    metadata\n        - namespace\n      metrics:\n      - name: \"labels\"\n        help:
-    \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n          type:
-    Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"target_info\"\n        help: \"Target
-    references that the backendtlspolicy wants to be attached to\"\n        each:\n
-    \         type: Info\n          info:\n            path: [spec, targetRef]\n            labelsFromPath:\n
-    \             target_group: [\"group\"]\n              target_kind: [\"kind\"]\n
-    \             target_name: [\"name\"]\n              target_namespace: [\"namespace\"]\n
-    \   - groupVersionKind:\n        group: kuadrant.io\n        kind: \"AuthPolicy\"\n
-    \       version: \"v1beta2\"\n      metricNamePrefix: gatewayapi_authpolicy\n
-    \     labelsFromPath:\n        name:\n        - metadata\n        - name\n        namespace:\n
-    \       - metadata\n        - namespace\n      metrics:\n      - name: \"labels\"\n
-    \       help: \"Kubernetes labels converted to Prometheus labels.\"\n        each:\n
-    \         type: Info\n          info:\n            path: [metadata]\n            labelsFromPath:\n
-    \             \"*\": [labels]\n      - name: \"created\"\n        help: \"created
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, creationTimestamp]\n      - name: \"deleted\"\n        help: \"deletion
-    timestamp\"\n        each:\n          type: Gauge\n          gauge:\n            path:
-    [metadata, deletionTimestamp]\n      - name: \"target_info\"\n        help: \"Target
-    references that the authpolicy wants to be attached to\"\n        each:\n          type:
-    Info\n          info:\n            path: [spec, targetRef]\n            labelsFromPath:\n
-    \             target_group: [\"group\"]\n              target_kind: [\"kind\"]\n
-    \             target_name: [\"name\"]\n              target_namespace: [\"namespace\"]\n
-    \     - name: \"status\"\n        help: \"status condition\"\n        each:\n
-    \         type: Gauge\n          gauge:\n            path: [status, conditions]\n
-    \           labelsFromPath:\n              type: [\"type\"]\n            valueFrom:
-    [\"status\"]"
+  custom-resource-state.yaml: |
+    kind: CustomResourceStateMetrics
+    spec:
+      resources:
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "Gateway"
+            version: "v1beta1"
+          metricNamePrefix: gatewayapi_gateway
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "info"
+            help: "Gateway information"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  gatewayclass_name: [spec, gatewayClassName]
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "listener_info"
+            help: "Gateway listener information"
+            each:
+              type: Info
+              info:
+                path: [spec, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                  port: ["port"]
+                  protocol: ["protocol"]
+                  hostname: ["hostname"]
+                  tls_mode: ["tls","mode"]
+                  allowed_routes_namespaces_from: ["allowedRoutes", "namespaces", "from"]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+          - name: "status_listener_attached_routes"
+            help: "Number of attached routes for a listener"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, listeners]
+                labelsFromPath:
+                  listener_name: ["name"]
+                valueFrom: ["attachedRoutes"]
+          - name: "status_address_info"
+            help: "Gateway address types and values"
+            each:
+              type: Info
+              info:
+                path: [status, addresses]
+                labelsFromPath:
+                  type: ["type"]
+                  value: ["value"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "GatewayClass"
+            version: "v1beta1"
+          metricNamePrefix: gatewayapi_gatewayclass
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+          metrics:
+          - name: "info"
+            help: "GatewayClass information"
+            each:
+              type: Info
+              info:
+                labelsFromPath:
+                  controller_name: [spec, controllerName]
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+          - name: "status_supported_features"
+            help: "List of supported features for the GatewayClass"
+            each:
+              type: Info
+              info:
+                path: [status, supportedFeatures]
+                labelsFromPath:
+                  features: []
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "HTTPRoute"
+            version: "v1beta1"
+          metricNamePrefix: gatewayapi_httproute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "hostname_info"
+            help: "Hostname information"
+            each:
+              type: Info
+              info:
+                path: [spec, hostnames]
+                labelsFromPath:
+                  hostname: []
+          - name: "parent_info"
+            help: "Parent references that the httproute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the httproute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "GRPCRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_grpcroute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "hostname_info"
+            help: "Hostname information"
+            each:
+              type: Info
+              info:
+                path: [spec, hostnames]
+                labelsFromPath:
+                  hostname: []
+          - name: "parent_info"
+            help: "Parent references that the grpcroute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the grpcroute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "TCPRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_tcproute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "parent_info"
+            help: "Parent references that the tcproute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the tcproute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "TLSRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_tlsroute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "hostname_info"
+            help: "Hostname information"
+            each:
+              type: Info
+              info:
+                path: [spec, hostnames]
+                labelsFromPath:
+                  hostname: []
+          - name: "parent_info"
+            help: "Parent references that the tlsroute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the tlsroute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "UDPRoute"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_udproute
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "parent_info"
+            help: "Parent references that the udproute wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, parentRefs]
+                labelsFromPath:
+                  parent_group: ["group"]
+                  parent_kind: ["kind"]
+                  parent_name: ["name"]
+                  parent_namespace: ["namespace"]
+                  parent_section_name: ["sectionName"]
+                  parent_port: ["port"]
+          - name: "status_parent_info"
+            help: "Parent references that the udproute is attached to"
+            each:
+              type: Info
+              info:
+                path: [status, parents]
+                labelsFromPath:
+                  controller_name: ["controllerName"]
+                  parent_group: ["parentRef", "group"]
+                  parent_kind: ["parentRef", "kind"]
+                  parent_name: ["parentRef", "name"]
+                  parent_namespace: ["parentRef", "namespace"]
+                  parent_section_name: ["parentRef", "sectionName"]
+                  parent_port: ["parentRef", "port"]
+        - groupVersionKind:
+            group: gateway.networking.k8s.io
+            kind: "BackendTLSPolicy"
+            version: "v1alpha2"
+          metricNamePrefix: gatewayapi_backendtlspolicy
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "target_info"
+            help: "Target references that the backendtlspolicy wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, targetRef]
+                labelsFromPath:
+                  target_group: ["group"]
+                  target_kind: ["kind"]
+                  target_name: ["name"]
+                  target_namespace: ["namespace"]
+        - groupVersionKind:
+            group: kuadrant.io
+            kind: "TLSPolicy"
+            version: "v1alpha1"
+          metricNamePrefix: gatewayapi_tlspolicy
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "target_info"
+            help: "Target references that the tlspolicy wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, targetRef]
+                labelsFromPath:
+                  target_group: ["group"]
+                  target_kind: ["kind"]
+                  target_name: ["name"]
+                  target_namespace: ["namespace"]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+        - groupVersionKind:
+            group: kuadrant.io
+            kind: "DNSPolicy"
+            version: "v1alpha1"
+          metricNamePrefix: gatewayapi_dnspolicy
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "target_info"
+            help: "Target references that the dnspolicy wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, targetRef]
+                labelsFromPath:
+                  target_group: ["group"]
+                  target_kind: ["kind"]
+                  target_name: ["name"]
+                  target_namespace: ["namespace"]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+        - groupVersionKind:
+            group: kuadrant.io
+            kind: "RateLimitPolicy"
+            version: "v1beta2"
+          metricNamePrefix: gatewayapi_ratelimitpolicy
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "target_info"
+            help: "Target references that the tlspolicy wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, targetRef]
+                labelsFromPath:
+                  target_group: ["group"]
+                  target_kind: ["kind"]
+                  target_name: ["name"]
+                  target_namespace: ["namespace"]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
+        - groupVersionKind:
+            group: kuadrant.io
+            kind: "AuthPolicy"
+            version: "v1beta2"
+          metricNamePrefix: gatewayapi_authpolicy
+          labelsFromPath:
+            name:
+            - metadata
+            - name
+            namespace:
+            - metadata
+            - namespace
+          metrics:
+          - name: "labels"
+            help: "Kubernetes labels converted to Prometheus labels."
+            each:
+              type: Info
+              info:
+                path: [metadata]
+                labelsFromPath:
+                  "*": [labels]
+          - name: "created"
+            help: "created timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, creationTimestamp]
+          - name: "deleted"
+            help: "deletion timestamp"
+            each:
+              type: Gauge
+              gauge:
+                path: [metadata, deletionTimestamp]
+          - name: "target_info"
+            help: "Target references that the authpolicy wants to be attached to"
+            each:
+              type: Info
+              info:
+                path: [spec, targetRef]
+                labelsFromPath:
+                  target_group: ["group"]
+                  target_kind: ["kind"]
+                  target_name: ["name"]
+                  target_namespace: ["namespace"]
+          - name: "status"
+            help: "status condition"
+            each:
+              type: Gauge
+              gauge:
+                path: [status, conditions]
+                labelsFromPath:
+                  type: ["type"]
+                valueFrom: ["status"]
 kind: ConfigMap
 metadata:
   name: custom-resource-state

--- a/config/examples/kube-prometheus/kustomization.yaml
+++ b/config/examples/kube-prometheus/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - github.com/prometheus-operator/kube-prometheus?ref=release-0.11
 # Use the github url instead of the relative path if using this outside the repo
 #  - github.com/kuadrant/gateway-api-state-metrics?ref=<release>
-  - ../../default
+  - ../../kuadrant
 # Include the example dashboars and rules if you want
   - ../dashboards
   - ../rules

--- a/config/kuadrant/crd/kuadrant.io_dnsrecords.yaml
+++ b/config/kuadrant/crd/kuadrant.io_dnsrecords.yaml
@@ -1,0 +1,500 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: dnsrecords.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSRecord
+    listKind: DNSRecordList
+    plural: dnsrecords
+    singular: dnsrecord
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSRecord ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSRecord is the Schema for the dnsrecords API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSRecordSpec defines the desired state of DNSRecord
+            properties:
+              endpoints:
+                description: endpoints is a list of endpoints that will be published
+                  into the dns provider.
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                minItems: 1
+                type: array
+              healthCheck:
+                description: |-
+                  HealthCheckSpec configures health checks in the DNS provider.
+                  By default this health check will be applied to each unique DNS A Record for
+                  the listeners assigned to the target gateway
+                properties:
+                  endpoint:
+                    description: |-
+                      Endpoint is the path to append to the host to reach the expected health check.
+                      Must start with "?" or "/", contain only valid URL characters and end with alphanumeric char or "/". For example "/" or "/healthz" are common
+                    pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
+                    type: string
+                  failureThreshold:
+                    description: FailureThreshold is a limit of consecutive failures
+                      that must occur for a host to be considered unhealthy
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Failure threshold must be greater than 0
+                      rule: self > 0
+                  port:
+                    description: Port to connect to the host on. Must be either 80,
+                      443 or 1024-49151
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Only ports 80, 443, 1024-49151 are allowed
+                      rule: self in [80, 443] || (self >= 1024 && self <= 49151)
+                  protocol:
+                    description: Protocol to use when connecting to the host, valid
+                      values are "HTTP" or "HTTPS"
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Only HTTP or HTTPS protocols are allowed
+                      rule: self in ['HTTP','HTTPS']
+                type: object
+              ownerID:
+                description: |-
+                  ownerID is a unique string used to identify the owner of this record.
+                  If unset or set to an empty string the record UID will be used.
+                maxLength: 36
+                minLength: 6
+                type: string
+                x-kubernetes-validations:
+                - message: OwnerID is immutable
+                  rule: self == oldSelf
+              providerRef:
+                description: providerRef is a reference to a provider secret.
+                properties:
+                  name:
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              rootHost:
+                description: |-
+                  rootHost is the single root for all endpoints in a DNSRecord.
+                  it is expected all defined endpoints are children of or equal to this rootHost
+                  Must contain at least two groups of valid URL characters separated by a "."
+                maxLength: 255
+                minLength: 1
+                pattern: ^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$
+                type: string
+                x-kubernetes-validations:
+                - message: RootHost is immutable
+                  rule: self == oldSelf
+            required:
+            - providerRef
+            - rootHost
+            type: object
+            x-kubernetes-validations:
+            - message: OwnerID can't be unset if it was previously set
+              rule: '!has(oldSelf.ownerID) || has(self.ownerID)'
+            - message: OwnerID can't be set if it was previously unset
+              rule: has(oldSelf.ownerID) || !has(self.ownerID)
+          status:
+            description: DNSRecordStatus defines the observed state of DNSRecord
+            properties:
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the record in the dns provider.
+
+
+                  If publishing the record fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              domainOwners:
+                description: DomainOwners is a list of all the owners working against
+                  the root domain of this record
+                items:
+                  type: string
+                type: array
+              endpoints:
+                description: endpoints are the last endpoints that were successfully
+                  published to the provider zone
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              healthCheck:
+                properties:
+                  conditions:
+                    items:
+                      description: "Condition contains details for one aspect of the
+                        current state of this API Resource.\n---\nThis struct is intended
+                        for direct use as an array at the field path .status.conditions.
+                        \ For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents
+                        the observations of a foo's current state.\n\t    // Known
+                        .status.conditions.type are: \"Available\", \"Progressing\",
+                        and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
+                        \   // +listType=map\n\t    // +listMapKey=type\n\t    Conditions
+                        []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\"
+                        patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                        \   // other fields\n\t}"
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: |-
+                            type of condition in CamelCase or in foo.example.com/CamelCase.
+                            ---
+                            Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                            useful (see .node.status.conditions), the ability to deconflict is important.
+                            The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  probes:
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            description: "Condition contains details for one aspect
+                              of the current state of this API Resource.\n---\nThis
+                              struct is intended for direct use as an array at the
+                              field path .status.conditions.  For example,\n\n\n\ttype
+                              FooStatus struct{\n\t    // Represents the observations
+                              of a foo's current state.\n\t    // Known .status.conditions.type
+                              are: \"Available\", \"Progressing\", and \"Degraded\"\n\t
+                              \   // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t
+                              \   // +listType=map\n\t    // +listMapKey=type\n\t
+                              \   Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                              patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                              \   // other fields\n\t}"
+                            properties:
+                              lastTransitionTime:
+                                description: |-
+                                  lastTransitionTime is the last time the condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: |-
+                                  message is a human readable message indicating details about the transition.
+                                  This may be an empty string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: |-
+                                  observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                  For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                  with respect to the current state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: |-
+                                  reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define expected values and meanings for this field,
+                                  and whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string.
+                                  This field may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
+                                enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                                type: string
+                              type:
+                                description: |-
+                                  type of condition in CamelCase or in foo.example.com/CamelCase.
+                                  ---
+                                  Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                                  useful (see .node.status.conditions), the ability to deconflict is important.
+                                  The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        host:
+                          type: string
+                        id:
+                          type: string
+                        ipAddress:
+                          type: string
+                        synced:
+                          type: boolean
+                      required:
+                      - host
+                      - id
+                      - ipAddress
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the DNSRecord.
+                format: int64
+                type: integer
+              ownerID:
+                description: ownerID is a unique string used to identify the owner
+                  of this record.
+                type: string
+              queuedAt:
+                description: QueuedAt is a time when DNS record was received for the
+                  reconciliation
+                format: date-time
+                type: string
+              validFor:
+                description: ValidFor indicates duration since the last reconciliation
+                  we consider data in the record to be valid
+                type: string
+              writeCounter:
+                description: |-
+                  WriteCounter represent a number of consecutive write attempts on the same generation of the record.
+                  It is being reset to 0 when the generation changes or there are no changes to write.
+                format: int64
+                type: integer
+              zoneDomainName:
+                description: zoneDomainName is the domain name of the zone that the
+                  dns record is publishing endpoints
+                type: string
+              zoneID:
+                description: zoneID is the provider specific id to which this dns
+                  record is publishing endpoints
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/kuadrant/custom-resource-state-kuadrant.yaml
+++ b/config/kuadrant/custom-resource-state-kuadrant.yaml
@@ -1,0 +1,251 @@
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "TLSPolicy"
+        version: "v1alpha1"
+      metricNamePrefix: gatewayapi_tlspolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the tlspolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "DNSPolicy"
+        version: "v1alpha1"
+      metricNamePrefix: gatewayapi_dnspolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the dnspolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "RateLimitPolicy"
+        version: "v1beta2"
+      metricNamePrefix: gatewayapi_ratelimitpolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the tlspolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "AuthPolicy"
+        version: "v1beta2"
+      metricNamePrefix: gatewayapi_authpolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the authpolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "DNSRecord"
+        version: "v1alpha1"
+      metricNamePrefix: kuadrant_dnsrecord            
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace 
+        rootDomain:
+        - spec
+        - rootHost     
+      metrics:
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]      
+      - name: "status_root_domain_owners"
+        help: "root domain owners (the ids of controllers managing this root domain)"
+        each:
+          type: Info
+          info:
+            path: [status, domainOwners]
+            labelsFromPath:
+              owner: []
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]

--- a/config/kuadrant/custom-resource-state-kuadrant.yaml
+++ b/config/kuadrant/custom-resource-state-kuadrant.yaml
@@ -214,24 +214,24 @@
         group: kuadrant.io
         kind: "DNSRecord"
         version: "v1alpha1"
-      metricNamePrefix: kuadrant_dnsrecord            
+      metricNamePrefix: kuadrant_dnsrecord
       labelsFromPath:
         name:
         - metadata
         - name
         namespace:
         - metadata
-        - namespace 
+        - namespace
         rootDomain:
         - spec
-        - rootHost     
+        - rootHost
       metrics:
       - name: "created"
         help: "created timestamp"
         each:
           type: Gauge
           gauge:
-            path: [metadata, creationTimestamp]      
+            path: [metadata, creationTimestamp]
       - name: "status_root_domain_owners"
         help: "root domain owners (the ids of controllers managing this root domain)"
         each:

--- a/config/kuadrant/custom-resource-state.yaml
+++ b/config/kuadrant/custom-resource-state.yaml
@@ -715,3 +715,42 @@ spec:
             labelsFromPath:
               type: ["type"]
             valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "DNSRecord"
+        version: "v1alpha1"
+      metricNamePrefix: kuadrant_dnsrecord
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+        rootDomain:
+        - spec
+        - rootHost
+      metrics:
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "status_root_domain_owners"
+        help: "root domain owners (the ids of controllers managing this root domain)"
+        each:
+          type: Info
+          info:
+            path: [status, domainOwners]
+            labelsFromPath:
+              owner: []
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]

--- a/config/kuadrant/custom-resource-state.yaml
+++ b/config/kuadrant/custom-resource-state.yaml
@@ -503,3 +503,215 @@ spec:
               target_kind: ["kind"]
               target_name: ["name"]
               target_namespace: ["namespace"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "TLSPolicy"
+        version: "v1alpha1"
+      metricNamePrefix: gatewayapi_tlspolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the tlspolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "DNSPolicy"
+        version: "v1alpha1"
+      metricNamePrefix: gatewayapi_dnspolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the dnspolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "RateLimitPolicy"
+        version: "v1beta2"
+      metricNamePrefix: gatewayapi_ratelimitpolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the tlspolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+    - groupVersionKind:
+        group: kuadrant.io
+        kind: "AuthPolicy"
+        version: "v1beta2"
+      metricNamePrefix: gatewayapi_authpolicy
+      labelsFromPath:
+        name:
+        - metadata
+        - name
+        namespace:
+        - metadata
+        - namespace
+      metrics:
+      - name: "labels"
+        help: "Kubernetes labels converted to Prometheus labels."
+        each:
+          type: Info
+          info:
+            path: [metadata]
+            labelsFromPath:
+              "*": [labels]
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+      - name: "target_info"
+        help: "Target references that the authpolicy wants to be attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, targetRef]
+            labelsFromPath:
+              target_group: ["group"]
+              target_kind: ["kind"]
+              target_name: ["name"]
+              target_namespace: ["namespace"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]

--- a/config/kuadrant/kustomization.yaml
+++ b/config/kuadrant/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: custom-resource-state
+  namespace: monitoring
+  files:
+  - custom-resource-state.yaml

--- a/hack/gen_kuadrant_custom_resource_state.sh
+++ b/hack/gen_kuadrant_custom_resource_state.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Paths to the input files and the output file
+file1="./config/default/custom-resource-state.yaml"
+file2="./config/kuadrant/custom-resource-state-kuadrant.yaml"
+output_file="./config/kuadrant/custom-resource-state.yaml"
+
+# Ensure the directory for the output file exists
+mkdir -p "$(dirname "$output_file")"
+
+# Append the contents of file1 and file2, and write to output_file
+cat "$file1" "$file2" > "$output_file"
+
+echo "Contents of $file1 and $file2 have been combined into $output_file"

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -133,7 +133,7 @@ kubectl create -f ./config/gateway-api/crd/standard/
 kubectl create -f ./config/kuadrant/crd/
 
 # create gateway-api customresourcestatemetrics configmap
-kubectl create configmap custom-resource-state --from-file=./config/default/custom-resource-state.yaml --dry-run=client -o yaml | kubectl -n kube-system apply -f -
+kubectl create configmap custom-resource-state --from-file=./config/kuadrant/custom-resource-state.yaml --dry-run=client -o yaml | kubectl -n kube-system apply -f -
 
 # set up kube-state-metrics manifests
 kubectl create -f ./config/examples/kube-state-metrics/service-account.yaml
@@ -165,7 +165,7 @@ echo "kube-state-metrics is up and running"
 echo "start e2e test for kube-state-metrics"
 KSM_HTTP_METRICS_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy'
 KSM_TELEMETRY_URL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:telemetry/proxy'
-go test -v ./tests/e2e/main_test.go --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL}
+go test -mod=readonly -v ./tests/e2e/main_test.go --ksm-http-metrics-url=${KSM_HTTP_METRICS_URL} --ksm-telemetry-url=${KSM_TELEMETRY_URL}
 
 # TODO: re-implement the following test cases in Go with the goal of removing this file.
 echo "access kube-state-metrics metrics endpoint"

--- a/tests/manifests/testdnsrecord.yaml
+++ b/tests/manifests/testdnsrecord.yaml
@@ -1,0 +1,129 @@
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSRecord
+metadata:
+  name: testdnsrecord1
+  namespace: default
+spec:
+  endpoints:
+  - dnsName: 15cku8-29fy65.klb.test.cb.hcpapps.net
+    recordTTL: 60
+    recordType: A
+    targets:
+    - 172.18.0.17
+  - dnsName: eu.klb.test.cb.hcpapps.net
+    providerSpecific:
+    - name: weight
+      value: "120"
+    recordTTL: 60
+    recordType: CNAME
+    setIdentifier: 15cku8-29fy65.klb.test.cb.hcpapps.net
+    targets:
+    - 15cku8-29fy65.klb.test.cb.hcpapps.net
+  - dnsName: klb.test.cb.hcpapps.net
+    providerSpecific:
+    - name: geo-code
+      value: EU
+    recordTTL: 300
+    recordType: CNAME
+    setIdentifier: EU
+    targets:
+    - eu.klb.test.cb.hcpapps.net
+  - dnsName: klb.test.cb.hcpapps.net
+    providerSpecific:
+    - name: geo-code
+      value: '*'
+    recordTTL: 300
+    recordType: CNAME
+    setIdentifier: default
+    targets:
+    - eu.klb.test.cb.hcpapps.net
+  - dnsName: test.cb.hcpapps.net
+    recordTTL: 300
+    recordType: CNAME
+    targets:
+    - klb.test.cb.hcpapps.net
+  providerRef:
+    name: my-aws-credentials
+  rootHost: test.cb.hcpapps.net
+status:
+  conditions:
+  - lastTransitionTime: "2024-09-18T07:41:17Z"
+    message: Provider ensured the dns record
+    observedGeneration: 1
+    reason: ProviderSuccess
+    status: "True"
+    type: Ready
+  domainOwners:
+  - k4ww8e00
+  - mvg80cg8
+  endpoints:
+  - dnsName: 15cku8-29fy65.klb.test.cb.hcpapps.net
+    labels:
+      owner: k4ww8e00
+    recordTTL: 60
+    recordType: A
+    targets:
+    - 172.18.0.17
+  - dnsName: eu.klb.test.cb.hcpapps.net
+    labels:
+      owner: k4ww8e00
+    providerSpecific:
+    - name: alias
+      value: "false"
+    - name: aws/weight
+      value: "120"
+    recordTTL: 60
+    recordType: CNAME
+    setIdentifier: 15cku8-29fy65.klb.test.cb.hcpapps.net
+    targets:
+    - 15cku8-29fy65.klb.test.cb.hcpapps.net
+  - dnsName: klb.test.cb.hcpapps.net
+    labels:
+      owner: k4ww8e00&&mvg80cg8
+    providerSpecific:
+    - name: alias
+      value: "false"
+    - name: aws/geolocation-continent-code
+      value: EU
+    recordTTL: 300
+    recordType: CNAME
+    setIdentifier: EU
+    targets:
+    - eu.klb.test.cb.hcpapps.net
+  - dnsName: klb.test.cb.hcpapps.net
+    labels:
+      owner: k4ww8e00&&mvg80cg8
+    providerSpecific:
+    - name: alias
+      value: "false"
+    - name: aws/geolocation-country-code
+      value: '*'
+    recordTTL: 300
+    recordType: CNAME
+    setIdentifier: default
+    targets:
+    - eu.klb.test.cb.hcpapps.net
+  - dnsName: test.cb.hcpapps.net
+    labels:
+      owner: k4ww8e00&&mvg80cg8
+    providerSpecific:
+    - name: alias
+      value: "false"
+    recordTTL: 300
+    recordType: CNAME
+    targets:
+    - klb.test.cb.hcpapps.net
+  healthCheck:
+    conditions:
+    - lastTransitionTime: "2024-09-18T08:59:31Z"
+      message: all 0 probes synced successfully
+      observedGeneration: 1
+      reason: AllProbesSynced
+      status: "True"
+      type: healthProbesSynced
+  observedGeneration: 1
+  ownerID: k4ww8e00
+  queuedAt: "2024-09-18T08:59:21Z"
+  validFor: 10m40s
+  zoneDomainName: cb.hcpapps.net
+  zoneID: /hostedzone/Z020652020A1X1WYHNUQ0


### PR DESCRIPTION
This change splits out the kuadrant specific resources (TLSPolicy, AuthPolicy etc...) into a separate kustomization file that generates a customresourcestate configmap with both the gateway api config and kuadrant resource config combined.

To do this, the base configmap is appended to with the kuadrant resources, and the resulting file is checked in.
A workflow action ensures the latest content is always generated if the base file or kaudrant specific file changes.

This change splits out & adds new test for the kuadrant DNSRecord resource (though existing kuadrant resource tests remain under the `gatewayapi_` prefix for backwards compatibility for now).
The existing e2e tests script behaves as before, testing all gateway api and kuadrant resources.

After a new release (latest is 0.4.0 at this time), the default behaviour when you pull in the kustomization.yaml file in the root of the repo will now only include the metrics config for gateway api resources.

To include the metrics config for both the gateway api resources and kuadrant resources, the ./config/kuadrant/kustomization.yaml file will need to be included.
(In the kaudrant-operator, this line will need to be updated https://github.com/Kuadrant/kuadrant-operator/blob/main/config/observability/kustomization.yaml#L6)

For example:
```yaml
resources:
  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.x.0
```
