### PR TITLE
chore: fixed null messages for deletedtimestamp metadata

### DIFF
--- a/config/default/custom-resource-state.yaml
+++ b/config/default/custom-resource-state.yaml
@@ -41,6 +41,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "listener_info"
         help: "Gateway listener information"
         each:
@@ -118,6 +119,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "status"
         help: "status condition"
         each:
@@ -168,6 +170,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "hostname_info"
         help: "Hostname information"
         each:
@@ -236,6 +239,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "hostname_info"
         help: "Hostname information"
         each:
@@ -304,6 +308,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "parent_info"
         help: "Parent references that the tcproute wants to be attached to"
         each:
@@ -364,6 +369,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "hostname_info"
         help: "Hostname information"
         each:
@@ -432,6 +438,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "parent_info"
         help: "Parent references that the udproute wants to be attached to"
         each:
@@ -492,6 +499,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "target_info"
         help: "Target references that the backendtlspolicy wants to be attached to"
         each:

--- a/config/examples/kube-prometheus/bundle.yaml
+++ b/config/examples/kube-prometheus/bundle.yaml
@@ -1026,6 +1026,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "listener_info"
             help: "Gateway listener information"
             each:
@@ -1103,6 +1104,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "status"
             help: "status condition"
             each:
@@ -1153,6 +1155,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "hostname_info"
             help: "Hostname information"
             each:
@@ -1221,6 +1224,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "hostname_info"
             help: "Hostname information"
             each:
@@ -1289,6 +1293,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "parent_info"
             help: "Parent references that the tcproute wants to be attached to"
             each:
@@ -1349,6 +1354,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "hostname_info"
             help: "Hostname information"
             each:
@@ -1417,6 +1423,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "parent_info"
             help: "Parent references that the udproute wants to be attached to"
             each:
@@ -1477,6 +1484,7 @@ data:
               type: Gauge
               gauge:
                 path: [metadata, deletionTimestamp]
+                nilIsZero: true
           - name: "target_info"
             help: "Target references that the backendtlspolicy wants to be attached to"
             each:

--- a/config/kuadrant/custom-resource-state.yaml
+++ b/config/kuadrant/custom-resource-state.yaml
@@ -41,6 +41,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "listener_info"
         help: "Gateway listener information"
         each:
@@ -118,6 +119,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "status"
         help: "status condition"
         each:
@@ -168,6 +170,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "hostname_info"
         help: "Hostname information"
         each:
@@ -236,6 +239,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "hostname_info"
         help: "Hostname information"
         each:
@@ -304,6 +308,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "parent_info"
         help: "Parent references that the tcproute wants to be attached to"
         each:
@@ -364,6 +369,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "hostname_info"
         help: "Hostname information"
         each:
@@ -432,6 +438,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "parent_info"
         help: "Parent references that the udproute wants to be attached to"
         each:
@@ -492,6 +499,7 @@ spec:
           type: Gauge
           gauge:
             path: [metadata, deletionTimestamp]
+            nilIsZero: true
       - name: "target_info"
         help: "Target references that the backendtlspolicy wants to be attached to"
         each:


### PR DESCRIPTION
Fix these errors:

```
E1029 13:33:21.096938 1 registry_factory.go:688] "gatewayapi_gatewayclass_deleted" err="[metadata,deletionTimestamp]: got nil while resolving path"
E1029 13:33:21.097015 1 registry_factory.go:688] "gatewayapi_gatewayclass_deleted" err="[metadata,deletionTimestamp]: got nil while resolving path"
E1029 13:33:21.107526 1 registry_factory.go:688] "gatewayapi_gateway_deleted" err="[metadata,deletionTimestamp]: got nil while resolving path"
E1029 13:33:21.107714 1 registry_factory.go:688] "gatewayapi_gateway_deleted" err="[metadata,deletionTimestamp]: got nil while resolving path"
```
#53 